### PR TITLE
Updated lwt to fix length but in qos and retain

### DIFF
--- a/ELClient/ELClientMqtt.cpp
+++ b/ELClient/ELClientMqtt.cpp
@@ -66,11 +66,13 @@ void ELClientMqtt::setup(void) {
 @endcode
 */
 void ELClientMqtt::lwt(const char* topic, const char* message, uint8_t qos, uint8_t retain) {
+  long l_qos = qos;
+  long l_retain = retain;
   _elc->Request(CMD_MQTT_LWT, 0, 4);
   _elc->Request(topic, strlen(topic));
   _elc->Request(message, strlen(message));
-  _elc->Request(&qos, 1);
-  _elc->Request(&retain, 1);
+  _elc->Request(&l_qos, 4);
+  _elc->Request(&l_retain, 4);
   _elc->Request();
 }
 


### PR DESCRIPTION
esp-link expects 4 bytes apiece for qos and retain parameters.  This implementation only sends 1 byte for each, therefore the retain parameter is never properly read.  This update fixes this.